### PR TITLE
Using a pre-built images needs no `build` but a `compose`

### DIFF
--- a/Running-Mastodon/Docker-Guide.md
+++ b/Running-Mastodon/Docker-Guide.md
@@ -32,7 +32,7 @@ To use the prebuilt images:
    2. Edit the `image: tootsuite/mastodon` lines for all images to include the release you want. The default is `latest` which is the most recent stable version, however it recommended to explicitly pin a version: If you wanted to use v2.2.0 for example, you would edit the lines to say: `image: tootsuite/mastodon:v2.2.0`
    3. Save the file and exit the text editor.
 2. Run `cp .env.production.sample .env.production` to bootstrap the configuration. You will need to edit this file later.
-3. Run `docker-compose build`. It will now pull the correct image from Docker Hub.
+3. Run `docker-compose pull`. It will now pull the correct image from Docker Hub.
 4. Set correct file-owner with `chown -R 991:991 public`
 
 ### Building your own image


### PR DESCRIPTION
It makes no sense (and effectively is a no-op) to do `docker-compose build` using pre-built images.